### PR TITLE
Added xmlns:android to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+    	xmlns:android="http://schemas.android.com/apk/res/android"
 	id="com.evothings.ble"
 	version="0.0.1">
 


### PR DESCRIPTION
Added xmlns:android so that visual studio will correctly import the plugin via new "Cordova Tools for Visual Studio".
