### PR TITLE
Update EVOBLE.m

### DIFF
--- a/src/ios/EVOBLE.m
+++ b/src/ios/EVOBLE.m
@@ -1249,7 +1249,11 @@ static int EVOPerhiperalAssociatedObjectKey = 42;
 	if([self isSafeToCopy:o])
 		return o;
 	if([o.class isSubclassOfClass:CBUUID.class]) {
-		return [(CBUUID*)o UUIDString];
+		if (floor(NSFoundationVersionNumber) < NSFoundationVersionNumber_iOS_7_1){
+	           return [(CBUUID*)o uuidString];
+	        } else {
+	           return [(CBUUID*)o UUIDString];
+	        }
 	}
 	if([o.class isSubclassOfClass:NSData.class]) {
 		return [(NSData*)o base64EncodedStringWithOptions:0];


### PR DESCRIPTION
UUIDString is not available < iOS 7.1. And there are still lots of devices running iOS 7.0.x.
Avoid app being crashed under iOS 7.0.x.