### PR TITLE
Added guard to check existence of callbackContext to prevent NullPointerException

### DIFF
--- a/src/android/BLE.java
+++ b/src/android/BLE.java
@@ -161,19 +161,25 @@ public class BLE extends CordovaPlugin implements LeScanCallback {
 	private void keepCallback(final CallbackContext callbackContext, JSONObject message) {
 		PluginResult r = new PluginResult(PluginResult.Status.OK, message);
 		r.setKeepCallback(true);
-		callbackContext.sendPluginResult(r);
+		if (callbackContext != null) {
+			callbackContext.sendPluginResult(r);
+		}
 	}
 
 	private void keepCallback(final CallbackContext callbackContext, String message) {
 		PluginResult r = new PluginResult(PluginResult.Status.OK, message);
 		r.setKeepCallback(true);
-		callbackContext.sendPluginResult(r);
+		if (callbackContext != null) {
+			callbackContext.sendPluginResult(r);
+		}
 	}
 
 	private void keepCallback(final CallbackContext callbackContext, byte[] message) {
 		PluginResult r = new PluginResult(PluginResult.Status.OK, message);
 		r.setKeepCallback(true);
-		callbackContext.sendPluginResult(r);
+		if (callbackContext != null) {
+			callbackContext.sendPluginResult(r);
+		}
 	}
 
 	// API implementation. See ble.js for documentation.


### PR DESCRIPTION
Hi guys,

I was intermittently getting an error on an Android device that caused the whole app to crash:

`Shutting down VM
E/AndroidRuntime(31057): FATAL EXCEPTION: main
E/AndroidRuntime(31057): Process: net.memberoo.mobileapp, PID: 31057
E/AndroidRuntime(31057): java.lang.NullPointerException: Attempt to invoke virtual method 'void org.apache.cordova.CallbackContext.sendPluginResult(org.apache.cordova.PluginResult)' on a null object reference
E/AndroidRuntime(31057):    at com.evothings.BLE.keepCallback(BLE.java:164)
E/AndroidRuntime(31057):    at com.evothings.BLE.onLeScan(BLE.java:207)
E/AndroidRuntime(31057):    at android.bluetooth.BluetoothAdapter$3.onScanResult(BluetoothAdapter.java:2406)
E/AndroidRuntime(31057):    at android.bluetooth.le.BluetoothLeScanner$BleScanCallbackWrapper$1.run(BluetoothLeScanner.java:393)
E/AndroidRuntime(31057):    at android.os.Handler.handleCallback(Handler.java:739)
E/AndroidRuntime(31057):    at android.os.Handler.dispatchMessage(Handler.java:95)
E/AndroidRuntime(31057):    at android.os.Looper.loop(Looper.java:145)
E/AndroidRuntime(31057):    at android.app.ActivityThread.main(ActivityThread.java:6837)
E/AndroidRuntime(31057):    at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(31057):    at java.lang.reflect.Method.invoke(Method.java:372)
E/AndroidRuntime(31057):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1404)
E/AndroidRuntime(31057):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1199)
V/ApplicationPolicy( 3516): isApplicationStateBlocked userId 0 pkgname net.memberoo.mobileapp
W/ActivityManager( 3516):   Force finishing activity 1 net.memberoo.mobileapp/.MainActivity
D/FocusedStackFrame( 3516): Set to : 0`

I've added in a few guards to check that `callbackContext` isn't null and it seems to stop the app crashing.